### PR TITLE
fix: build errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,13 +15,13 @@ readme = "README.md"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8"
 async-trait = "0.1.40"
-casbin = {  version = "2.0" }
-tokio = { version = "0.3.1", default-features = false, optional = true }
+casbin = { version = "2.0", default-features = false }
+tokio = { version = "1.36.0", default-features = false, optional = true }
 async-std = { version = "1.6.4", default-features = false, optional = true }
 
 [dev-dependencies]
 async-std = { version = "1.6.4", features = [ "attributes" ] }
-tokio = { version = "0.3.1", features = [ "full" ] }
+tokio = { version = "1.36.0", features = [ "full" ] }
 
 [features]
 default = ["runtime-async-std"]

--- a/src/yaml_adapter.rs
+++ b/src/yaml_adapter.rs
@@ -31,7 +31,7 @@ impl<P> Adapter for YamlAdapter<P>
 where
     P: AsRef<Path> + Send + Sync,
 {
-    async fn load_policy(&self, m: &mut dyn Model) -> Result<()> {
+    async fn load_policy(&mut self, m: &mut dyn Model) -> Result<()> {
         self.load_filtered_policy_into_model(
             m,
             Filter {


### PR DESCRIPTION
Fix the build errors

- Disable default `casbin` feature flags
- Upgrade `tokio` since the old version is broken
- Edit adapter signature to met the latest trait definition